### PR TITLE
chore: Update Ruby and MySQL versions for testing, remove rexml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,11 @@
 AllCops:
-  TargetRubyVersion: 2.4.6
+  TargetRubyVersion: 3.4
   Exclude:
     - 'vendor/**/*'
     - 'bin/{console,setup}'
 
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
 
 Style/ClassAndModuleChildren:
   Enabled: false
@@ -43,10 +40,10 @@ Style/RedundantSelf:
 Style/RegexpLiteral:
   AllowInnerSlashes: true
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table
 
@@ -57,10 +54,10 @@ Lint/AmbiguousBlockAssociation:
 Layout/ExtraSpacing:
   AllowForAlignment: true
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallBraceLayout:
@@ -69,7 +66,7 @@ Layout/MultilineMethodCallBraceLayout:
 Layout/SpaceInsideBlockBraces:
   EnforcedStyleForEmptyBraces: space
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'spec/**/*'
 
@@ -88,7 +85,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 10
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
   IgnoredPatterns:
     - "'.+'"                                                      # Text

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0-alpine3.8
+FROM ruby:3.4-alpine
 
 # Create application directory.
 RUN mkdir /app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,15 @@
 PATH
   remote: .
   specs:
-    mysql2-aurora (0.5.6)
+    mysql2-aurora (0.5.6.1)
       mysql2 (~> 0.5.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
+    ast (2.4.3)
+    base64 (0.2.0)
+    bigdecimal (3.3.1)
     coderay (1.1.3)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -17,21 +19,23 @@ GEM
       tins (~> 1.6)
     diff-lcs (1.5.1)
     docile (1.4.0)
-    json (2.7.1)
+    json (2.17.1)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     method_source (1.0.0)
     mysql2 (0.5.6)
-    parallel (1.24.0)
-    parser (3.3.0.5)
+    parallel (1.27.0)
+    parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
+    prism (1.6.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.7.3)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.0)
-    regexp_parser (2.9.0)
-    rexml (3.2.6)
+    regexp_parser (2.11.3)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -45,17 +49,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (0.93.1)
+    rubocop (1.81.7)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8)
-      rexml
-      rubocop-ast (>= 0.6.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.48.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
     ruby-progressbar (1.13.0)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -68,7 +75,9 @@ GEM
     thor (1.3.1)
     tins (1.32.1)
       sync
-    unicode-display_width (1.8.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
     yard (0.9.36)
 
 PLATFORMS
@@ -76,13 +85,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64 (~> 0.2)
+  bigdecimal (~> 3.3)
   bundler (>= 1.16)
   coveralls (~> 0.8)
   mysql2-aurora!
   pry (~> 0.12)
   rake (~> 13.0)
   rspec (~> 3.0)
-  rubocop (~> 0.62)
+  rubocop (~> 1.0)
   simplecov (~> 0.16)
   yard (~> 0.9)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     build:
@@ -12,6 +11,6 @@ services:
     depends_on:
       - mysql
   mysql:
-    image: mysql:5.7
+    image: mysql:8
     environment:
       MYSQL_ROOT_PASSWORD: 'change_me'

--- a/lib/mysql2/aurora.rb
+++ b/lib/mysql2/aurora.rb
@@ -52,7 +52,7 @@ module Mysql2
       # Reconnect to database and Set `@client`
       # @note If client is not connected, Connect to database.
       def reconnect!
-        query_options = (@client&.query_options&.dup || {})
+        query_options = @client&.query_options&.dup || {}
 
         disconnect!
 
@@ -71,7 +71,7 @@ module Mysql2
       # @param [String] name  Method name
       # @param [Array]  args  Method arguments
       # @param [Proc]   block Method block
-      def method_missing(name, *args, &block) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
+      def method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
         client.public_send(name, *args, &block)
       end
 
@@ -79,7 +79,7 @@ module Mysql2
       # @param [String] name  Method name
       # @param [Array]  args  Method arguments
       # @param [Proc]   block Method block
-      def self.method_missing(name, *args, &block) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
+      def self.method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
         Mysql2::Aurora::ORIGINAL_CLIENT_CLASS.public_send(name, *args, &block)
       end
 

--- a/lib/mysql2/aurora/version.rb
+++ b/lib/mysql2/aurora/version.rb
@@ -3,6 +3,6 @@ module Mysql2
     # Major Version: Support `mysql2` major version.
     # Minor Version: Support `mysql2` minor version.
     # Tiny Version:  Mysql2::Aurora version.
-    VERSION = '0.5.6'.freeze
+    VERSION = '0.5.6.1'.freeze
   end
 end

--- a/mysql2-aurora.gemspec
+++ b/mysql2-aurora.gemspec
@@ -18,16 +18,18 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(/^(test|spec|features)\//) }
   end
 
-  spec.required_ruby_version = '>= 2.4.6'
+  spec.required_ruby_version = '>= 3.4'
 
   spec.add_dependency 'mysql2', '~> 0.5.6'
 
-  spec.add_development_dependency 'bundler',   '>= 1.16'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
-  spec.add_development_dependency 'pry',       '~> 0.12'
-  spec.add_development_dependency 'rake',      '~> 13.0'
-  spec.add_development_dependency 'rspec',     '~> 3.0'
-  spec.add_development_dependency 'rubocop',   '~> 0.62'
-  spec.add_development_dependency 'simplecov', '~> 0.16'
-  spec.add_development_dependency 'yard',      '~> 0.9'
+  spec.add_development_dependency 'base64',     '~> 0.2'
+  spec.add_development_dependency 'bigdecimal', '~> 3.3'
+  spec.add_development_dependency 'bundler',    '>= 1.16'
+  spec.add_development_dependency 'coveralls',  '~> 0.8'
+  spec.add_development_dependency 'pry',        '~> 0.12'
+  spec.add_development_dependency 'rake',       '~> 13.0'
+  spec.add_development_dependency 'rspec',      '~> 3.0'
+  spec.add_development_dependency 'rubocop',    '~> 1.0'
+  spec.add_development_dependency 'simplecov',  '~> 0.16'
+  spec.add_development_dependency 'yard',       '~> 0.9'
 end

--- a/spec/mysql2/aurora_spec.rb
+++ b/spec/mysql2/aurora_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Mysql2::Aurora::Client do
         password:                      ENV['TEST_DB_PASS'],
         aurora_max_retry:              10,
         aurora_disconnect_on_readonly: aurora_disconnect_on_readonly,
-        flags: ["MULTI_STATEMENTS"]
+        flags:                         ['MULTI_STATEMENTS']
       )
     end
 


### PR DESCRIPTION
Testing doesn't work at the moment, so I've updated the Ruby and MySQL versions and some of the new config for Rubocop. All tests now pass.

The newer Ruby version needs base64 and bigdecimal gems declared.

Rubocop also needed updating due to some incompatibility. This has removed the dependency on rexml -- I was originally trying to update it due to some security advisories, but it turns out we can just remove it instead! I've also needed to make some config and formatting changes to accomodate new lint failures.

## Testing

`docker-compose run --build --rm app ./bin/test` works as expected.

I've deployed to in15 and staging, and tried a few deployments with no issue. I will also try it on int again once I've got a tagged release.